### PR TITLE
fix: prevent unnecessary cache cleanup on every get_app_open_counts_dict call

### DIFF
--- a/src/utils/app_history.py
+++ b/src/utils/app_history.py
@@ -27,16 +27,15 @@ def get_app_open_counts_dict() -> dict[str, AppOpenCounts]:
         except Exception:
             _app_open_counts_cache = {}
 
-    datetime_30d_ago = datetime.datetime.now() - datetime.timedelta(days=30)
-
-    # Remove entries older than 30 days
-    for app_exec in list(_app_open_counts_cache.keys()):
-        obj = _app_open_counts_cache[app_exec]
-        recent_open = datetime.datetime.strptime(
-            obj["recent_open"], "%Y-%m-%d %H:%M:%S"
-        )
-        if recent_open < datetime_30d_ago:
-            _app_open_counts_cache.pop(app_exec, None)
+        # Remove entries older than 30 days
+        datetime_30d_ago = datetime.datetime.now() - datetime.timedelta(days=30)
+        for app_exec in list(_app_open_counts_cache.keys()):
+            obj = _app_open_counts_cache[app_exec]
+            recent_open = datetime.datetime.strptime(
+                obj["recent_open"], "%Y-%m-%d %H:%M:%S"
+            )
+            if recent_open < datetime_30d_ago:
+                _app_open_counts_cache.pop(app_exec, None)
 
     return _app_open_counts_cache
 


### PR DESCRIPTION
Sorry, I made a small mistake. 😛

This fixes an issue where expired entries were unnecessarily cleaned multiple times. A single cleanup during file loading is sufficient.